### PR TITLE
fix(deposit_firestore): `primaryColumn` is getting stored in Firestore

### DIFF
--- a/packages/deposit_firestore/lib/src/firestore_deposit_adapter.dart
+++ b/packages/deposit_firestore/lib/src/firestore_deposit_adapter.dart
@@ -25,11 +25,6 @@ class FirestoreDepositAdapter extends DepositAdapter<String> {
     String primaryColumn,
     Map<String, dynamic> data,
   ) async {
-    assert(
-      data[primaryColumn] == null,
-      'Firestore adapter only works with auto generated ids, '
-      'be sure to pass null on primary column',
-    );
 
     final _data = { ...data };
     _data.remove(primaryColumn);

--- a/packages/deposit_firestore/lib/src/firestore_deposit_adapter.dart
+++ b/packages/deposit_firestore/lib/src/firestore_deposit_adapter.dart
@@ -25,7 +25,16 @@ class FirestoreDepositAdapter extends DepositAdapter<String> {
     String primaryColumn,
     Map<String, dynamic> data,
   ) async {
-    final value = await _firestore.collection(table).add(data);
+    assert(
+      data[primaryColumn] == null,
+      'Firestore adapter only works with auto generated ids, '
+      'be sure to pass null on primary column',
+    );
+
+    final _data = { ...data };
+    _data.remove(primaryColumn);
+
+    final value = await _firestore.collection(table).add(_data);
 
     final snapshot = await value.snapshots().first;
     final returnedData = snapshot.data();

--- a/packages/deposit_firestore/test/firestore_deposit_test.dart
+++ b/packages/deposit_firestore/test/firestore_deposit_test.dart
@@ -35,6 +35,7 @@ void main() {
         final snapshot = await instance.collection('cars').get();
 
         expect(snapshot.docs.length, equals(1));
+        expect(snapshot.docs.first.id, isA<String>());
         expect(snapshot.docs.first['brand'], equals('VW'));
         expect(snapshot.docs.first['model'], equals('Nivus'));
       });


### PR DESCRIPTION
Firestore wasn't correcting saving the id column.